### PR TITLE
implement units

### DIFF
--- a/src/sinks/sentry/metrics/sink.rs
+++ b/src/sinks/sentry/metrics/sink.rs
@@ -22,6 +22,14 @@ fn finish_metric(source_metric: &SourceMetric, mut sentry_metric: MetricBuilder)
         }
     }
 
+    if let Some(meta_object) = source_metric.metadata().value().as_object() {
+        if let Some(unit) = meta_object.get("sentry_unit") {
+            if let Some(unit) = unit.as_str() {
+                sentry_metric = sentry_metric.with_unit(unit.into_owned());
+            }
+        }
+    }
+
     // we need to carry forward the original timestamp as otherwise the SDK will use the current
     // time. otherwise this causes bad visual artifacts when backpressure happens and unnecessarily
     // relies on vector's system clock.


### PR DESCRIPTION
With this, people can use VRL to set `sentry_unit` like this:

```
      if .namespace == "system" && starts_with(to_string(.name) ?? "", ".mem") {
        %sentry_unit = "megabyte"
      }

      if .namespace == "docker" && starts_with(to_string(.name) ?? "", ".mem") {
        %sentry_unit = "megabyte"
      }

      if .namespace == "system" && starts_with(to_string(.name) ?? "", ".swap") {
        %sentry_unit = "megabyte"
      }

      if .namespace == "system" && starts_with(to_string(.name) ?? "", ".net.bytes") {
        %sentry_unit = "byte"
      }

```